### PR TITLE
fix: wrong error messages for missing keys when parsing maps

### DIFF
--- a/lib/src/types/map.dart
+++ b/lib/src/types/map.dart
@@ -99,7 +99,7 @@ class AcanthisMap<V> extends AcanthisType<Map<String, V>> {
       final isNullable = field.value is AcanthisNullable;
       final passedValue = value[key];
       if (passedValue == null && !isOptional && !isNullable) {
-        final checks = field.value.operations.cast<AcanthisCheck>();
+        final checks = field.value.operations.whereType<AcanthisCheck>();
         final validationErrors = [
           'Field $key is required',
           for (final check in checks) check.error,
@@ -163,7 +163,7 @@ class AcanthisMap<V> extends AcanthisType<Map<String, V>> {
       final key = entry.key;
       final isOptional = _optionalFields.contains(key);
       if (!value.containsKey(key) && !isOptional) {
-        final checks = entry.value.operations.cast<AcanthisCheck>();
+        final checks = entry.value.operations.whereType<AcanthisCheck>();
         final validationErrors = [
           'Field $key is required',
           for (final check in checks) check.error,
@@ -233,7 +233,7 @@ class AcanthisMap<V> extends AcanthisType<Map<String, V>> {
       if (!passedValue.containsKey(key) &&
           !isOptional &&
           field.value is! AcanthisNullable) {
-        final checks = field.value.operations.cast<AcanthisCheck>();
+        final checks = field.value.operations.whereType<AcanthisCheck>();
         final validationErrors = {
           'required': 'Field is required',
           for (final check in checks) check.name: check.error,
@@ -321,7 +321,7 @@ class AcanthisMap<V> extends AcanthisType<Map<String, V>> {
       final key = field.key;
       final isOptional = _optionalFields.contains(key);
       if (!value.containsKey(key) && !isOptional) {
-        final checks = field.value.operations.cast<AcanthisCheck>();
+        final checks = field.value.operations.whereType<AcanthisCheck>();
         final validationErrors = {
           'required': 'Field is required',
           for (final check in checks) check.name: check.error,

--- a/lib/src/types/map.dart
+++ b/lib/src/types/map.dart
@@ -99,7 +99,14 @@ class AcanthisMap<V> extends AcanthisType<Map<String, V>> {
       final isNullable = field.value is AcanthisNullable;
       final passedValue = value[key];
       if (passedValue == null && !isOptional && !isNullable) {
-        throw ValidationError('Field $field is required');
+        final checks = field.value.operations.cast<AcanthisCheck>();
+        final validationErrors = [
+          'Field $key is required',
+          for (final check in checks) check.error,
+        ];
+        final errorMessage = '${validationErrors.join('.\n')}.';
+
+        throw ValidationError(errorMessage);
       }
       if (passedValue == null && isOptional && !isNullable) {
         continue;
@@ -156,7 +163,14 @@ class AcanthisMap<V> extends AcanthisType<Map<String, V>> {
       final key = entry.key;
       final isOptional = _optionalFields.contains(key);
       if (!value.containsKey(key) && !isOptional) {
-        throw ValidationError('Field $key is required');
+        final checks = entry.value.operations.cast<AcanthisCheck>();
+        final validationErrors = [
+          'Field $key is required',
+          for (final check in checks) check.error,
+        ];
+        final errorMessage = '${validationErrors.join('.\n')}.';
+
+        throw ValidationError(errorMessage);
       }
       if (value[key] == null &&
           isOptional &&
@@ -219,7 +233,13 @@ class AcanthisMap<V> extends AcanthisType<Map<String, V>> {
       if (!passedValue.containsKey(key) &&
           !isOptional &&
           field.value is! AcanthisNullable) {
-        errors[key] = {'required': 'Field is required'};
+        final checks = field.value.operations.cast<AcanthisCheck>();
+        final validationErrors = {
+          'required': 'Field is required',
+          for (final check in checks) check.name: check.error,
+        };
+
+        errors[key] = validationErrors;
         continue;
       }
       if (passedValue[key] == null &&
@@ -301,7 +321,13 @@ class AcanthisMap<V> extends AcanthisType<Map<String, V>> {
       final key = field.key;
       final isOptional = _optionalFields.contains(key);
       if (!value.containsKey(key) && !isOptional) {
-        errors[key] = {'required': 'Field is required'};
+        final checks = field.value.operations.cast<AcanthisCheck>();
+        final validationErrors = {
+          'required': 'Field is required',
+          for (final check in checks) check.name: check.error,
+        };
+
+        errors[key] = validationErrors;
         continue;
       }
       if (value[key] == null &&

--- a/lib/src/types/string.dart
+++ b/lib/src/types/string.dart
@@ -114,8 +114,15 @@ class AcanthisString extends AcanthisType<String> {
   }
 
   /// Add a check to the string to check if it is not empty
+  @Deprecated(
+      'Use notEmpty() instead; required() will be removed in a future release.')
   AcanthisString required({String? message}) {
     return withCheck(RequiredStringCheck(message: message));
+  }
+
+  /// Add a check to the string to check if it is not empty
+  AcanthisString notEmpty({String? message}) {
+    return withCheck(NotEmptyStringCheck(message: message));
   }
 
   /// Add a check to the string to check if it's length is exactly [length]

--- a/lib/src/validators/string.dart
+++ b/lib/src/validators/string.dart
@@ -439,6 +439,17 @@ class RequiredStringCheck extends AcanthisCheck<String> {
   }
 }
 
+/// String Check for non-empty String validation.
+class NotEmptyStringCheck extends AcanthisCheck<String> {
+  const NotEmptyStringCheck({String? message})
+      : super(error: message ?? 'Value must not be empty', name: 'notEmpty');
+
+  @override
+  bool call(String value) {
+    return value.isNotEmpty;
+  }
+}
+
 /// String check for containing a specific substring.
 class ContainsStringCheck extends AcanthisCheck<String> {
   final String value;

--- a/test/types/map_test.dart
+++ b/test/types/map_test.dart
@@ -28,7 +28,33 @@ void main() {
 
       expect(result.success, false);
 
-      expect(() => map.parse({}), throwsA(TypeMatcher<ValidationError>()));
+      expect(
+        result.errors,
+        equals(
+          {
+            'key': {
+              'required': 'Field is required',
+              'minLength':
+                  'Value must be greater than or equal to 5 characters long',
+              'maxLength':
+                  'Value must be less than or equal to 20 characters long',
+            }
+          },
+        ),
+      );
+
+      expect(
+        () => map.parse({}),
+        throwsA(
+          TypeMatcher<ValidationError>().having(
+            (error) => error.message,
+            'ValidationError message property contains every check error message',
+            equals(
+              'Field key is required.\nValue must be greater than or equal to 5 characters long.\nValue must be less than or equal to 20 characters long.',
+            ),
+          ),
+        ),
+      );
     });
 
     test(

--- a/test/types/string_test.dart
+++ b/test/types/string_test.dart
@@ -170,6 +170,32 @@ void main() {
     });
 
     test(
+        'when creating a string validator with a notEmpty check,'
+        'and the string is empty, '
+        'then the result should be unsuccessful', () {
+      final string = acanthis.string().notEmpty();
+      final result = string.tryParse('');
+
+      expect(result.success, false);
+
+      expect(() => string.parse(''), throwsA(TypeMatcher<ValidationError>()));
+    });
+
+    test(
+        'when creating a string validator with a notEmpty check,'
+        'and the string is not empty, '
+        'then the result should be successful', () {
+      final string = acanthis.string().notEmpty();
+      final result = string.tryParse('test');
+
+      expect(result.success, true);
+
+      final resultParse = string.parse('test');
+
+      expect(resultParse.success, true);
+    });
+
+    test(
         'when creating a string validator with an email check,'
         'and the string is a valid email, '
         'then the result should be successful', () {

--- a/test/types/string_test.dart
+++ b/test/types/string_test.dart
@@ -147,6 +147,7 @@ void main() {
         'when creating a string validator with a required check,'
         'and the string is empty, '
         'then the result should be unsuccessful', () {
+      // ignore: deprecated_member_use_from_same_package
       final string = acanthis.string().required();
       final result = string.tryParse('');
 
@@ -159,6 +160,7 @@ void main() {
         'when creating a string validator with a required check,'
         'and the string is not empty, '
         'then the result should be successful', () {
+      // ignore: deprecated_member_use_from_same_package
       final string = acanthis.string().required();
       final result = string.tryParse('test');
 


### PR DESCRIPTION
# Description

This PR fixes the wrong error message from `ValidationError` thrown in `AcanthisMap.parse`. 
Previously, the `parse` method was throwing an error message with a MapEntry instance, instead of using the missing key name.

Also, I took advantage to improve the `ValidationError` message when using `parse` along with `errors` from `AcanthisParseResult` from `tryParse`, they now include the full checks errors instead of just the "Field is required" message:

**When using `parse`**
```dart
final map = acanthis.object({'key': acanthis.string().min(5).max(20)});
final result = map.parse({});
```
**Throws**
```cmd
Unhandled exception:
ValidationError: Field key is required.
Value must be greater than or equal to 5 characters long.
Value must be less than or equal to 20 characters long.
```

**When using `tryParse`**
```dart
final map = acanthis.object({'key': acanthis.string().min(5).max(20)});
final result = map.tryParse({});
```
**Using `result.errors` we obtain**
```cmd
{
    "key": {
        "required": "Field is required",
        "minLength": "Value must be greater than or equal to 5 characters long",
        "maxLength": "Value must be less than or equal to 20 characters long"
    }
}
```

Along with these changes, I've added a new check for `AcanthisString` to validate empty strings, it is named `NotEmptyStringCheck`, it's purpose is to replace the `RequiredStringCheck` in the future.

The method `required()` has been marked as **deprecated** and we are encouraging developers to use the new check `notEmpty()` instead. The reason behind is having a more easy-to understand check.

**Before**
```dart
final schema = acanthis.object({'key': acanthis.string().required()});
```
**Now**
```dart
final schema = acanthis.object({'key': acanthis.string().notEmpty()});
```

Fixes [ValidationError: Field MapEntry(userName: Instance of 'AcanthisString') is required](https://discord.com/channels/1099781506978807919/1396313233677094974)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new string validation method to ensure values are not empty.
  * Enhanced error reporting for missing required fields, providing more detailed validation messages.

* **Deprecation**
  * Marked the existing string "required" validation method as deprecated in favor of the new "not empty" check.

* **Bug Fixes**
  * Improved test coverage and accuracy for validation error messages and new string validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->