### PR TITLE
fix(#14): change list parse values to dynamic values

### DIFF
--- a/lib/src/types/list.dart
+++ b/lib/src/types/list.dart
@@ -17,7 +17,8 @@ class AcanthisList<T> extends AcanthisType<List<T>> {
       {super.operations, super.isAsync, super.key});
 
   @override
-  Future<AcanthisParseResult<List<T>>> parseAsync(List<dynamic> value) async {
+  Future<AcanthisParseResult<List<T>>> parseAsync(
+      covariant List<dynamic> value) async {
     final parsed = <T>[];
     for (var i = 0; i < value.length; i++) {
       final parsedElement = await element.parseAsync(value[i]);
@@ -27,7 +28,8 @@ class AcanthisList<T> extends AcanthisType<List<T>> {
   }
 
   @override
-  Future<AcanthisParseResult<List<T>>> tryParseAsync(List<dynamic> value) async {
+  Future<AcanthisParseResult<List<T>>> tryParseAsync(
+      covariant List<dynamic> value) async {
     final parsed = <T>[];
     final errors = <String, dynamic>{};
     for (var i = 0; i < value.length; i++) {
@@ -38,16 +40,19 @@ class AcanthisList<T> extends AcanthisType<List<T>> {
       }
     }
     final result = await super.tryParseAsync(parsed);
+    final mergedErrors = {...errors, ...result.errors};
     return AcanthisParseResult(
-        value: result.value, errors: result.errors, metadata: result.metadata);
+        value: result.value,
+        errors: mergedErrors,
+        metadata: result.metadata,
+        success: _recursiveSuccess(mergedErrors));
   }
 
   /// Override of [parse] from [AcanthisType]
   @override
-  AcanthisParseResult<List<T>> parse(List<dynamic> value) {
+  AcanthisParseResult<List<T>> parse(covariant List<dynamic> value) {
     if (isAsync) {
-      throw AsyncValidationException(
-          'Cannot use tryParse with async operations');
+      throw AsyncValidationException('Cannot use parse with async operations');
     }
     return super.parse(List.generate(
       value.length,
@@ -58,7 +63,7 @@ class AcanthisList<T> extends AcanthisType<List<T>> {
 
   /// Override of [tryParse] from [AcanthisType]
   @override
-  AcanthisParseResult<List<T>> tryParse(List<dynamic> value) {
+  AcanthisParseResult<List<T>> tryParse(covariant List<dynamic> value) {
     if (isAsync) {
       throw AsyncValidationException(
           'Cannot use tryParse with async operations');
@@ -73,10 +78,11 @@ class AcanthisList<T> extends AcanthisType<List<T>> {
       }
     }
     final result = super.tryParse(parsed);
+    final mergedErrors = {...errors, ...result.errors};
     return AcanthisParseResult(
         value: result.value,
-        errors: errors..addAll(result.errors),
-        success: _recursiveSuccess(errors),
+        errors: mergedErrors,
+        success: _recursiveSuccess(mergedErrors),
         metadata: result.metadata);
   }
 

--- a/lib/src/types/list.dart
+++ b/lib/src/types/list.dart
@@ -17,7 +17,7 @@ class AcanthisList<T> extends AcanthisType<List<T>> {
       {super.operations, super.isAsync, super.key});
 
   @override
-  Future<AcanthisParseResult<List<T>>> parseAsync(List<T> value) async {
+  Future<AcanthisParseResult<List<T>>> parseAsync(List<dynamic> value) async {
     final parsed = <T>[];
     for (var i = 0; i < value.length; i++) {
       final parsedElement = await element.parseAsync(value[i]);
@@ -27,7 +27,7 @@ class AcanthisList<T> extends AcanthisType<List<T>> {
   }
 
   @override
-  Future<AcanthisParseResult<List<T>>> tryParseAsync(List<T> value) async {
+  Future<AcanthisParseResult<List<T>>> tryParseAsync(List<dynamic> value) async {
     final parsed = <T>[];
     final errors = <String, dynamic>{};
     for (var i = 0; i < value.length; i++) {
@@ -44,7 +44,7 @@ class AcanthisList<T> extends AcanthisType<List<T>> {
 
   /// Override of [parse] from [AcanthisType]
   @override
-  AcanthisParseResult<List<T>> parse(List<T> value) {
+  AcanthisParseResult<List<T>> parse(List<dynamic> value) {
     if (isAsync) {
       throw AsyncValidationException(
           'Cannot use tryParse with async operations');
@@ -58,7 +58,7 @@ class AcanthisList<T> extends AcanthisType<List<T>> {
 
   /// Override of [tryParse] from [AcanthisType]
   @override
-  AcanthisParseResult<List<T>> tryParse(List<T> value) {
+  AcanthisParseResult<List<T>> tryParse(List<dynamic> value) {
     if (isAsync) {
       throw AsyncValidationException(
           'Cannot use tryParse with async operations');


### PR DESCRIPTION
# Description

The list validators now accepts dynamic values in the parse methods.

Fixes #14 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for parsing lists containing any type of elements, not just strictly typed lists, in both synchronous and asynchronous parsing methods.
  * Improved error reporting by merging parsing errors more comprehensively for better feedback during list processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->