### PR TITLE
fix: prevent type cast crash when using date() inside object() with a string value

### DIFF
--- a/lib/src/types/date.dart
+++ b/lib/src/types/date.dart
@@ -134,6 +134,20 @@ class AcanthisDate extends AcanthisType<DateTime> {
   }
 
   @override
+  DateTime tryParseInternal(
+    dynamic value, {
+    required Map<String, dynamic> errors,
+  }) {
+    try {
+      final date = _convertToDate(value);
+      return super.tryParseInternal(date, errors: errors);
+    } on ValidationError catch (e) {
+      errors['date'] = e.message;
+      return defaultValue ?? DateTime.now();
+    }
+  }
+
+  @override
   AcanthisDate withAsyncCheck(AcanthisAsyncCheck<DateTime> check) {
     return AcanthisDate(
       operations: [...operations, check],

--- a/test/types/date_test.dart
+++ b/test/types/date_test.dart
@@ -322,5 +322,29 @@ void main() {
       expect(result['title'], 'Future Date');
       expect(result['examples'], ['2023-10-01T00:00:00.000']);
     });
+
+    test('when a date field inside an object receives a valid ISO 8601 string, '
+        'then tryParse should succeed and coerce to DateTime', () {
+      final schema = acanthis.object({
+        'name': acanthis.string(),
+        'close_at': acanthis.date(),
+      });
+
+      final result = schema.tryParse({
+        'name': 'test',
+        'close_at': '2026-06-10T10:20:52+00:00',
+      });
+
+      expect(result.success, true);
+    });
+
+    test('when a date field inside an object receives an invalid string, '
+        'then tryParse should fail without throwing', () {
+      final schema = acanthis.object({'close_at': acanthis.date()});
+
+      final result = schema.tryParse({'close_at': 'not-a-date'});
+
+      expect(result.success, false);
+    });
   });
 }


### PR DESCRIPTION
# Description

Calling `tryParse` on an `object()` schema containing a `date()` field with a raw `String` value threw an unhandled `TypeError` instead of returning a failed `AcanthisParseResult`.

Fixes #19 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced date field validation in object schemas with improved error handling for invalid date inputs.
  * Added support for parsing ISO 8601 date strings in date fields with better fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->